### PR TITLE
Verify GitHub evidences

### DIFF
--- a/packages/nextjs/components/attestation/UserAttestations.tsx
+++ b/packages/nextjs/components/attestation/UserAttestations.tsx
@@ -13,6 +13,8 @@ type Attestation = {
   skills: string[];
   description: string;
   evidences: string[];
+  evidencesVerified: boolean[];
+  evidencesColaborator: boolean[];
   timestamp: number;
 };
 
@@ -63,6 +65,8 @@ const fetchUserAttestations = async (
           skills
           description
           evidences
+          evidencesVerified
+          evidencesColaborator
           timestamp
         }
         pageInfo {
@@ -291,18 +295,34 @@ export const UserAttestations = ({ githubUser }: Props) => {
                   <div>
                     <h4 className="font-medium mb-2">Evidence:</h4>
                     <div className="flex flex-wrap gap-2">
-                      {attestation.evidences.map((evidence, idx) => (
-                        <a
-                          key={idx}
-                          href={evidence}
-                          target="_blank"
-                          rel="noreferrer"
-                          className="btn btn-sm btn-outline btn-primary text-xs"
-                          title={evidence}
-                        >
-                          {evidence.length > 40 ? `${evidence.substring(0, 40)}...` : evidence}
-                        </a>
-                      ))}
+                      {attestation.evidences.map((evidence, idx) => {
+                        const isVerified = attestation.evidencesVerified?.[idx] || false;
+                        const isColaborator = attestation.evidencesColaborator?.[idx] || false;
+
+                        let bgColor = "";
+                        let titleSuffix = "";
+
+                        if (isColaborator) {
+                          bgColor = "bg-green-100";
+                          titleSuffix = " (Verified and Collaborator)";
+                        } else if (isVerified) {
+                          bgColor = "bg-orange-100";
+                          titleSuffix = " (Verified)";
+                        }
+
+                        return (
+                          <a
+                            key={idx}
+                            href={evidence}
+                            target="_blank"
+                            rel="noreferrer"
+                            className={`btn btn-sm btn-outline btn-primary text-xs ${bgColor}`}
+                            title={evidence + titleSuffix}
+                          >
+                            {evidence.length > 40 ? `${evidence.substring(0, 40)}...` : evidence}
+                          </a>
+                        );
+                      })}
                     </div>
                   </div>
                 )}

--- a/packages/nextjs/components/attestation/UserAttestations.tsx
+++ b/packages/nextjs/components/attestation/UserAttestations.tsx
@@ -14,7 +14,7 @@ type Attestation = {
   description: string;
   evidences: string[];
   evidencesVerified: boolean[];
-  evidencesColaborator: boolean[];
+  evidencesCollaborator: boolean[];
   timestamp: number;
 };
 
@@ -66,7 +66,7 @@ const fetchUserAttestations = async (
           description
           evidences
           evidencesVerified
-          evidencesColaborator
+          evidencesCollaborator
           timestamp
         }
         pageInfo {
@@ -297,12 +297,12 @@ export const UserAttestations = ({ githubUser }: Props) => {
                     <div className="flex flex-wrap gap-2">
                       {attestation.evidences.map((evidence, idx) => {
                         const isVerified = attestation.evidencesVerified?.[idx] || false;
-                        const isColaborator = attestation.evidencesColaborator?.[idx] || false;
+                        const isCollaborator = attestation.evidencesCollaborator?.[idx] || false;
 
                         let bgColor = "";
                         let titleSuffix = "";
 
-                        if (isColaborator) {
+                        if (isCollaborator) {
                           bgColor = "bg-green-100";
                           titleSuffix = " (Verified and Collaborator)";
                         } else if (isVerified) {

--- a/packages/ponder/.env.example
+++ b/packages/ponder/.env.example
@@ -7,3 +7,6 @@ DATABASE_SCHEMA=my_schema
 # (Optional) Postgres database URL. If not provided, SQLite will be used.
 DATABASE_URL=
 
+REDIS_URL=
+GITHUB_TOKEN=
+

--- a/packages/ponder/package.json
+++ b/packages/ponder/package.json
@@ -16,6 +16,7 @@
     "drizzle-kit": "0.22.8",
     "hono": "^4.5.0",
     "ponder": "^0.8.15",
+    "redis": "^5.8.2",
     "viem": "^2.21.3"
   },
   "devDependencies": {

--- a/packages/ponder/ponder.schema.ts
+++ b/packages/ponder/ponder.schema.ts
@@ -8,6 +8,8 @@ export const attestation = onchainTable("attestation", (t) => ({
   skills: t.text().array().notNull(),
   description: t.text().notNull(),
   evidences: t.text().array().notNull(),
+  evidencesVerified: t.boolean().array(),
+  evidencesColaborator: t.boolean().array(),
   timestamp: t.integer().notNull(),
 }));
 
@@ -24,6 +26,8 @@ export const developerSkill = onchainTable(
     githubUser: t.text().notNull(),
     skill: t.text().notNull(),
     count: t.integer().notNull(),
+    verifiedCount: t.integer().notNull(),
+    colaboratorCount: t.integer().notNull(),
     score: t.integer().notNull(),
   }),
   (t) => ({

--- a/packages/ponder/ponder.schema.ts
+++ b/packages/ponder/ponder.schema.ts
@@ -9,7 +9,7 @@ export const attestation = onchainTable("attestation", (t) => ({
   description: t.text().notNull(),
   evidences: t.text().array().notNull(),
   evidencesVerified: t.boolean().array(),
-  evidencesColaborator: t.boolean().array(),
+  evidencesCollaborator: t.boolean().array(),
   timestamp: t.integer().notNull(),
 }));
 
@@ -27,7 +27,7 @@ export const developerSkill = onchainTable(
     skill: t.text().notNull(),
     count: t.integer().notNull(),
     verifiedCount: t.integer().notNull(),
-    colaboratorCount: t.integer().notNull(),
+    collaboratorCount: t.integer().notNull(),
     score: t.integer().notNull(),
   }),
   (t) => ({

--- a/yarn.lock
+++ b/yarn.lock
@@ -3879,6 +3879,7 @@ __metadata:
     eslint-config-ponder: ^0.8.15
     hono: ^4.5.0
     ponder: ^0.8.15
+    redis: ^5.8.2
     typescript: ^5.3.2
     viem: ^2.21.3
   languageName: unknown


### PR DESCRIPTION
- Verify GitHub evidence when indexing events from Ponder.
- Check on GitHub repository contributor y languages, looking for the attested username and the skill attested.
- Added verifiedCount to developerSkills: this is the count of attestations for this skill with valid evidence.
- Added collaboratorCount to developerSkills: this is the count of attestations for this skill with valid evidence, AND the attester user has contributed to the project too.
- Basic score calculation: one point for the attestation, one point if this is verified, and one point if it's from a collaborator (we can improve it later).
- Added evidencesVerified and evidencesCollaborator to attestations: so we can show an evidence as verified or from a collaborator.
- Added background color based on evidence verification on UserAttestations.

With all this new information available from Ponder GraphQL, we can improve the data shown in the website.

GITHUB_TOKEN is not needed if the GitHub API endpoints are hit only a couple of times, but then it's rate-limited.

One future improvement is to avoid adding more score to a user if the same user attests to a user more than once. Issue created for this #30 