### PR TITLE
fix for DisplayStats.tsx

### DIFF
--- a/packages/nextjs/components/DisplayStats.tsx
+++ b/packages/nextjs/components/DisplayStats.tsx
@@ -57,9 +57,9 @@ export const DisplayStats = () => {
   });
 
   const stats = [
-    { label: "Developers", value: statsData?.attestations?.totalCount || 0 },
-    { label: "Skills Attested", value: statsData?.developers?.totalCount || 0 },
-    { label: "Attestations", value: statsData?.developerSkills?.totalCount || 0 },
+    { label: "Developers", value: statsData?.developers?.totalCount || 0 },
+    { label: "Attestations", value: statsData?.attestations?.totalCount || 0 },
+    { label: "Skills Attested", value: statsData?.developerSkills?.totalCount || 0 },
   ];
 
   return (


### PR DESCRIPTION
While working on DisplayStats.tsx I've mixed up numbers & labels. 

This pr fixes it and puts them in more logical order.

<img width="415" height="164" alt="Screenshot 2025-09-25 at 14 39 20" src="https://github.com/user-attachments/assets/af8b2689-e356-4a20-bfe8-39ad213452c8" />

