### PR TITLE
Builder profile with GitHub data and stats

### DIFF
--- a/packages/nextjs/components/BuilderProfile.tsx
+++ b/packages/nextjs/components/BuilderProfile.tsx
@@ -1,20 +1,38 @@
 "use client";
 
+import { useMemo } from "react";
 import { Attestations } from "./builder/Attestations";
 import { ProfileHeader } from "./builder/ProfileHeader";
 import { Skills } from "./builder/Skills";
+import { useQuery } from "@tanstack/react-query";
+import { Developer } from "~~/types";
+import { fetchDeveloper } from "~~/utils/graphql";
 
 interface BuilderProfileProps {
   username: string;
 }
 
 export function BuilderProfile({ username }: BuilderProfileProps) {
+  const {
+    data: developerData,
+    isLoading: isDeveloperLoading,
+    isError: isDeveloperError,
+  } = useQuery({
+    queryKey: ["developer", username] as const,
+    queryFn: () => fetchDeveloper(username),
+    enabled: Boolean(username),
+  });
+
+  const developer = useMemo(() => developerData as Developer, [developerData]);
+
   return (
     <div className="mx-auto max-w-6xl space-y-8 p-4 sm:p-6 md:p-8">
-      <ProfileHeader username={username} />
+      {isDeveloperLoading && <div>Loading...</div>}
+      {isDeveloperError && <div>Error loading developer data.</div>}
+      {developer && <ProfileHeader developer={developer} />}
       <div className="grid grid-cols-1 gap-8 lg:grid-cols-3">
         <div className="lg:col-span-2">
-          <Attestations username={username} />
+          <Attestations developer={developer} isLoading={isDeveloperLoading} />
         </div>
         <div className="lg:col-span-1">
           <Skills username={username} />

--- a/packages/nextjs/components/builder/ProfileHeader.tsx
+++ b/packages/nextjs/components/builder/ProfileHeader.tsx
@@ -2,26 +2,16 @@ import Link from "next/link";
 import { ReusuableStats } from "../DisplayStats";
 import { GithubSVG } from "../assets/GithubSVG";
 import { ChatBubbleLeftRightIcon } from "@heroicons/react/24/outline";
+import { Developer } from "~~/types";
 
-const profile = {
-  credScore: 2847,
-  attestations: 156,
-  verifiedAttestations: 14,
-};
-
-function StatsGrid({ username }: { username: string }) {
-  console.log("Rendering stats for", username);
+export function ProfileHeader({ developer }: { developer: Developer }) {
+  const avatarUrl = `https://github.com/${developer.githubUser}.png`;
+  const githubUrl = `https://github.com/${developer.githubUser}`;
   const stats = [
-    { label: "Cred Score", value: profile.credScore },
-    { label: "Attestations", value: profile.attestations },
-    { label: "Verified Attestations", value: profile.verifiedAttestations },
+    { label: "Cred Score", value: developer.score },
+    { label: "Attestations", value: developer.attestationsCount },
+    { label: "Verified Attestations", value: developer.verifiedAttestationsCount },
   ];
-  return <ReusuableStats stats={stats} />;
-}
-
-export function ProfileHeader({ username }: { username: string }) {
-  const avatarUrl = `https://github.com/${username}.png`;
-  const githubUrl = `https://github.com/${username}`;
   return (
     <div className="card border border-base-300 bg-base-100 shadow-xl">
       <div className="card-body p-6 sm:p-8">
@@ -30,7 +20,7 @@ export function ProfileHeader({ username }: { username: string }) {
             <div className="avatar">
               <div className="mask mask-squircle h-28 w-28 sm:h-32 sm:w-32 bg-base-200">
                 {/* eslint-disable-next-line @next/next/no-img-element */}
-                <img src={avatarUrl} alt={username} />
+                <img src={avatarUrl} alt={developer.githubUser} />
               </div>
             </div>
             <div className="flex gap-2">
@@ -44,10 +34,10 @@ export function ProfileHeader({ username }: { username: string }) {
                 GitHub
               </Link>
               <Link
-                href={{ pathname: "/attest", query: { username } }}
+                href={{ pathname: "/attest", query: { username: developer.githubUser } }}
                 className="btn btn-primary btn-sm flex items-center gap-2"
                 prefetch={false}
-                aria-label={`Attest for ${username}`}
+                aria-label={`Attest for ${developer.githubUser}`}
               >
                 <ChatBubbleLeftRightIcon className="h-4 w-4" />
                 <span>Attest</span>
@@ -57,11 +47,11 @@ export function ProfileHeader({ username }: { username: string }) {
 
           <div className="flex-1 space-y-4 text-center md:text-left">
             <div>
-              <h1 className="text-3xl font-bold font-serif text-base-content sm:text-4xl">(find name from username)</h1>
-              <p className="text-base-content/70">@{username}</p>
-              <p className="mt-2 text-base-content text-sm sm:text-base">(placeholder for bio)</p>
+              <h1 className="text-3xl font-bold font-serif text-base-content sm:text-4xl">{developer.name}</h1>
+              <p className="text-base-content/70">@{developer.githubUser}</p>
+              <p className="mt-2 text-base-content text-sm sm:text-base">{developer.bio}</p>
             </div>
-            <StatsGrid username={username} />
+            <ReusuableStats stats={stats} />
           </div>
         </div>
       </div>

--- a/packages/nextjs/types/index.ts
+++ b/packages/nextjs/types/index.ts
@@ -38,7 +38,16 @@ type SkillsData = {
 
 type Developer = {
   githubUser: string;
-  description: string | null;
+  name: string;
+  bio: string;
+  location: string;
+  website: string;
+  twitter: string;
+  attestationsCount: number;
+  verifiedAttestationsCount: number;
+  colaboratorAttestationsCount: number;
+  score: number;
+  updatedAt: number;
   skills: {
     items: {
       skill: string;
@@ -49,6 +58,15 @@ type Developer = {
   attestations: {
     items: {
       id: string;
+      attester: string;
+      githubUser: string;
+      uid: string;
+      skills: string[];
+      description: string;
+      evidences: string[];
+      timestamp: number;
+      evidencesVerified: boolean[];
+      evidencesCollaborator: boolean[];
     }[];
   };
 };

--- a/packages/nextjs/utils/graphql.ts
+++ b/packages/nextjs/utils/graphql.ts
@@ -1,7 +1,11 @@
 import { gql, request } from "graphql-request";
 import { DeveloperForTable } from "~~/components/BuildersTable";
 import { PONDER_GRAPHQL_URL } from "~~/scaffold.config";
-import { AttestationsData, SearchData, SkillsData } from "~~/types";
+import { AttestationsData, Developer, SearchData, SkillsData } from "~~/types";
+
+type DeveloperResponse = {
+  developer: Developer;
+};
 
 export const fetchAttestations = async (pageSize: number = 20, cursor?: string) => {
   const AttestationsQuery = gql`
@@ -99,6 +103,50 @@ export const fetchUserSkills = async (githubUser: string): Promise<SkillsData> =
   });
 
   return data;
+};
+
+export const fetchDeveloper = async (githubUser: string): Promise<Developer> => {
+  const developerQuery = gql`
+    query Developer($githubUser: String!) {
+      developer(githubUser: $githubUser) {
+        githubUser
+        name
+        bio
+        location
+        website
+        twitter
+        attestationsCount
+        verifiedAttestationsCount
+        colaboratorAttestationsCount
+        score
+        updatedAt
+        skills(orderBy: "count", orderDirection: "desc") {
+          items {
+            skill
+            count
+            score
+          }
+        }
+        attestations(orderBy: "timestamp", orderDirection: "desc", limit: 5) {
+          items {
+            id
+            attester
+            uid
+            skills
+            description
+            evidences
+            timestamp
+          }
+        }
+      }
+    }
+  `;
+
+  const data = await request<DeveloperResponse>(PONDER_GRAPHQL_URL, developerQuery, {
+    githubUser: githubUser.toLowerCase(),
+  });
+
+  return data.developer;
 };
 
 export const searchDevelopers = async (githubUsername: string): Promise<SearchData> => {

--- a/packages/ponder/ponder.schema.ts
+++ b/packages/ponder/ponder.schema.ts
@@ -45,6 +45,16 @@ export const developerSkillRelations = relations(developerSkill, ({ one }) => ({
 
 export const developer = onchainTable("developer", (t) => ({
   githubUser: t.text().primaryKey(),
+  name: t.text(),
+  bio: t.text(),
+  location: t.text(),
+  website: t.text(),
+  twitter: t.text(),
+  attestationsCount: t.integer().notNull(),
+  verifiedAttestationsCount: t.integer().notNull(),
+  colaboratorAttestationsCount: t.integer().notNull(),
+  score: t.integer().notNull(),
+  updatedAt: t.integer().notNull(),
 }));
 
 export const developerRelations = relations(developer, ({ many }) => ({

--- a/packages/ponder/src/Attestations.ts
+++ b/packages/ponder/src/Attestations.ts
@@ -4,11 +4,20 @@ import scaffoldConfig from "../../nextjs/scaffold.config";
 import { SchemaEncoder } from "@ethereum-attestation-service/eas-sdk";
 import { EAS_ABI } from "../../nextjs/contracts/externalContracts";
 import { createClient } from "redis";
+import { eq } from "ponder";
 
 const redis = await createClient({ url: process.env.REDIS_URL }).connect();
 
 const targetNetwork = scaffoldConfig.targetNetworks[0];
 const easConfig = scaffoldConfig.easConfig[targetNetwork.id];
+interface GithubUser {
+    name: string;
+    bio: string;
+    location: string;
+    blog: string;
+    twitter_username: string;
+    updated_at: string;
+}
 
 ponder.on("EAS:Attested", async ({ event, context }) => {
     const { client } = context;
@@ -43,6 +52,8 @@ ponder.on("EAS:Attested", async ({ event, context }) => {
 
             const evidencesVerified: boolean[] = [];
             const evidencesCollaborator: boolean[] = [];
+
+            let score = skills.length;
 
             if (evidences.length > 0) {
                 const attesterUsername = await redis.get(`github:byAddress:${attester}`);
@@ -98,6 +109,22 @@ ponder.on("EAS:Attested", async ({ event, context }) => {
                 }
             }
 
+            for (let i = 0; i < skills.length; i++) {
+                const skill = skills[i];
+                if (!skill) {
+                    continue;
+                }
+                const evidenceData = evidencesData[skill.toLowerCase()];
+                if (evidenceData) {
+                    if (evidenceData.verified_count > 0) {
+                        score += 1;
+                    }
+                    if (evidenceData.collaborator_count > 0) {
+                        score += 1;
+                    }
+                }
+            }
+
             await context.db.insert(attestation).values({
                 id: event.log.id,
                 attester: attester,
@@ -111,9 +138,49 @@ ponder.on("EAS:Attested", async ({ event, context }) => {
                 timestamp: Number(event.block.timestamp),
             });
 
-            await context.db.insert(developer).values({
-                githubUser: githubUser,
-            }).onConflictDoNothing();
+            const headers: Record<string, string> = {};
+            if (process.env.GITHUB_TOKEN) {
+                headers.Authorization = `Bearer ${process.env.GITHUB_TOKEN}`;
+            }
+            const responseUser = await fetch(`https://api.github.com/users/${githubUser}`, { headers });
+            const dataUser : GithubUser = await responseUser.json() as GithubUser;
+
+            const developerData = await context.db.sql.query.developer.findFirst({
+                where: eq(developer.githubUser, githubUser),
+            });
+
+            let newDeveloperData: {
+                name: string | null;
+                bio: string | null;
+                location: string | null;
+                website: string | null;
+                twitter: string | null;
+                attestationsCount: number;
+                verifiedAttestationsCount: number;
+                colaboratorAttestationsCount: number;
+                score: number;
+                updatedAt: number;
+            } = {
+                name: dataUser.name,
+                bio: dataUser.bio,
+                location: dataUser.location,
+                website: dataUser.blog,
+                twitter: dataUser.twitter_username,
+                attestationsCount: (developerData ? developerData.attestationsCount : 0) + 1,
+                verifiedAttestationsCount: (developerData ? developerData.verifiedAttestationsCount : 0) + (evidencesVerified.some(verified => verified) ? 1 : 0),
+                colaboratorAttestationsCount: (developerData ? developerData.colaboratorAttestationsCount : 0) + (evidencesCollaborator.some(collaborator => collaborator) ? 1 : 0),
+                score: (developerData ? developerData.score : 0) + score,
+                updatedAt: Number(event.block.timestamp),
+            };
+
+            if (developerData) {
+                await context.db.update(developer, { githubUser: githubUser }).set(newDeveloperData);
+            } else {
+                await context.db.insert(developer).values({
+                    githubUser: githubUser,
+                    ...newDeveloperData,
+                }).onConflictDoNothing();
+            }
 
             for (let i = 0; i < skills.length; i++) {
                 const skill = skills[i];


### PR DESCRIPTION
- Added user data from GitHub to Ponder index.
- Added developer stats to developer Ponder entity.
- Fetch all the developer information from Ponder when showing the dev profile.
- Show dev real data, like name, bio, and stats (attestation, score, etc).
- Avoid running another query to show dev attestations. Only show the last 5 and link to the full attestations list.

Missing: avoid running another query to show the dev skills. We need to decide whether to showcase all the developer skills or only the best ones.

relates #36 