### PR TITLE
Add Dev Creds info to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,12 +91,12 @@ Built with Next.js, RainbowKit, Wagmi, Viem, TypeScript, and Ponder for blockcha
 
 - **Frontend (Next.js)**: Handles UI, wallet connections, and EAS contract interactions
 - **Ponder Indexer**: Listens for EAS `Attested` events, verifies GitHub evidence, and maintains the database
-- **Redis**: Caches GitHub API responses and manages user sessions
+- **Redis**: Stores mappings between GitHub accounts and wallet addresses
 - **EAS Contracts**: Stores attestations on-chain with immutable records
 
 ## Redis Setup
 
-This project uses Redis for caching GitHub data and managing sessions.
+This project uses Redis to persist GitHub account links to wallet addresses used by both Next.js and Ponder indexer.
 
 **Option 1: Redis Cloud (Recommended)**
 

--- a/README.md
+++ b/README.md
@@ -14,8 +14,6 @@ A decentralized developer credentials platform built with [Scaffold-ETH 2](https
 
 ---
 
-This repository was built with [Scaffold-ETH 2](https://github.com/scaffold-eth/scaffold-eth-2).
-
 ## Requirements
 
 Before you begin, you need to install the following tools:
@@ -185,6 +183,4 @@ For more information about EAS, visit the [Ethereum Attestation Service Document
 
 ## Contributing
 
-We welcome contributions to Dev Creds!
-
-Please feel free to submit issues and pull requests.
+We welcome contributions to Dev Creds! Please feel free to submit issues and pull requests.

--- a/README.md
+++ b/README.md
@@ -1,20 +1,20 @@
-# 🏗 Scaffold-ETH 2
+# Dev Creds
 
-<h4 align="center">
-  <a href="https://docs.scaffoldeth.io">Documentation</a> |
-  <a href="https://scaffoldeth.io">Website</a>
-</h4>
+![Dev Creds Sample](https://github.com/user-attachments/assets/d9e53927-984e-4191-9c35-341884df8fb4)
 
-🧪 An open-source, up-to-date toolkit for building decentralized applications (dapps) on the Ethereum blockchain. It's designed to make it easier for developers to create and deploy smart contracts and build user interfaces that interact with those contracts.
+A decentralized developer credentials platform built with [Scaffold-ETH 2](https://github.com/scaffold-eth/scaffold-eth-2) and the [Ethereum Attestation Service (EAS)](https://attest.org/). Developers can receive and give attestations for their skills, backed by verifiable GitHub evidence, creating an on-chain reputation system for builders.
 
-⚙️ Built using NextJS, RainbowKit, Wagmi, Viem, and Typescript.
+**Key features:**
 
-- 🪝 **[Custom hooks](https://docs.scaffoldeth.io/hooks/)**: Collection of React hooks wrapper around [wagmi](https://wagmi.sh/) to simplify interactions with smart contracts with typescript autocompletion.
-- 🧱 [**Components**](https://docs.scaffoldeth.io/components/): Collection of common web3 components to quickly build your frontend.
-- 🔥 **Burner Wallet & Local Faucet**: Quickly test your application with a burner wallet and local faucet.
-- 🔐 **Integration with Wallet Providers**: Connect to different wallet providers and interact with the Ethereum network.
+- Attest to other developers' skills with evidence from GitHub repositories
+- Automated verification through GitHub repository analysis
+- Reputation scoring based on attestations, verified evidence, and collaborator endorsements
+- Developer profiles showcasing skills and attestations
+- Multi-chain support (Optimism, Arbitrum, and other EAS-supported chains)
 
-![Debug Contracts tab](https://github.com/scaffold-eth/scaffold-eth-2/assets/55535804/b237af0c-5027-4849-a5c1-2e31495cccb1)
+---
+
+This repository was built with [Scaffold-ETH 2](https://github.com/scaffold-eth/scaffold-eth-2).
 
 ## Requirements
 
@@ -24,33 +24,167 @@ Before you begin, you need to install the following tools:
 - Yarn ([v1](https://classic.yarnpkg.com/en/docs/install/) or [v2+](https://yarnpkg.com/getting-started/install))
 - [Git](https://git-scm.com/downloads)
 
-## Quickstart
+## Development Quickstart
 
-To get started with Scaffold-ETH 2, follow the steps below:
-
-1. Install dependencies if it was skipped in CLI:
+1. Install dependencies
 
 ```
-cd my-dapp-example
 yarn install
 ```
-2. Start your NextJS app:
+
+2. Set up [Redis](#redis-setup) and [GitHub OAuth](#github-oauth-setup)
+
+3. Configure environment variables
+
+```
+cp packages/nextjs/.env.example packages/nextjs/.env.local
+cp packages/ponder/.env.example packages/ponder/.env.local
+```
+
+Edit both `.env.local` files with your configuration values.
+
+4. Start the Ponder indexer (in one terminal):
+
+```
+yarn ponder:dev
+```
+
+5. Start your NextJS app (in another terminal):
 
 ```
 yarn start
 ```
 
-Visit your app on: `http://localhost:3000`. You can interact with your smart contract using the `Debug Contracts` page. You can tweak the app config in `packages/nextjs/scaffold.config.ts`.
+Visit your app on: `http://localhost:3000`.
 
+## How It Works
+
+### Attestation Flow
+
+1. **Create Attestation** - Users attest to another developer's skills by providing:
+
+   - GitHub username
+   - List of skills (e.g., Solidity, React, TypeScript)
+   - Description of the developer's strengths
+   - GitHub repository URLs as evidence
+
+2. **Automatic Verification** - Ponder indexes the attestation and:
+
+   - Verifies the attested user is a contributor to the provided repositories
+   - Analyzes repository languages to confirm claimed skills
+   - Checks if the attester and attestee are collaborators
+   - Calculates a reputation score
+
+3. **Profile Building** - Developer profiles aggregate:
+   - All received attestations
+   - Verified vs. unverified attestations
+   - Skills with counts and verification status
+   - Overall reputation score
+
+### Scoring System
+
+- **Base Score**: +1 point per skill attested
+- **Verified Evidence**: +1 point per skill when repository languages match the claimed skill
+- **Collaborator Bonus**: +1 point per skill when attester and attestee collaborated on the same repository
+
+### Architecture
+
+Built with Next.js, RainbowKit, Wagmi, Viem, TypeScript, and Ponder for blockchain indexing.
+
+- **Frontend (Next.js)**: Handles UI, wallet connections, and EAS contract interactions
+- **Ponder Indexer**: Listens for EAS `Attested` events, verifies GitHub evidence, and maintains the database
+- **Redis**: Caches GitHub API responses and manages user sessions
+- **EAS Contracts**: Stores attestations on-chain with immutable records
+
+## Redis Setup
+
+This project uses Redis for caching GitHub data and managing sessions.
+
+**Option 1: Redis Cloud (Recommended)**
+
+1. Go to [Redis Cloud](https://redis.io/cloud/) and create a free database (30MB is sufficient)
+2. After creation, go to your database settings
+3. Copy the connection string from the "Public endpoint" section
+   - Format: `redis://default:password@host.redis-cloud.com:port`
+4. Use this as your `REDIS_URL` in both `.env.local` files
+
+You can connect locally with `redis-cli` for debugging:
+
+```bash
+# Install redis-cli: brew install redis (macOS) or sudo apt-get install redis-tools (Linux/WSL2)
+redis-cli -u "redis://default:password@host.redis-cloud.com:port"
+```
+
+**Option 2: Local Redis (Development)**
+
+```bash
+# macOS
+brew install redis && brew services start redis
+
+# Linux
+sudo apt-get install redis-server && sudo systemctl start redis
+
+# Windows (WSL2)
+sudo apt-get install redis-server && sudo service redis-server start
+```
+
+Then use `REDIS_URL=redis://localhost:6379` in your `.env.local` files.
+
+## GitHub OAuth Setup
+
+1. Go to [GitHub Developer Settings](https://github.com/settings/developers)
+2. Click "New OAuth App"
+3. Fill in:
+   - **Application name**: Dev Creds Local
+   - **Homepage URL**: `http://localhost:3000`
+   - **Authorization callback URL**: `http://localhost:3000/api/auth/callback/github`
+4. Copy the Client ID and Secret to your `.env.local` files
+
+## Environment Variables
+
+**NextJS** (`packages/nextjs/.env.local`):
+
+```bash
+NEXT_PUBLIC_ALCHEMY_API_KEY=       # Get from https://dashboard.alchemyapi.io
+NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID=  # Get from https://cloud.walletconnect.com
+GITHUB_ID=                         # GitHub OAuth App ID
+GITHUB_SECRET=                     # GitHub OAuth App Secret
+NEXTAUTH_SECRET=                   # Generate with: openssl rand -base64 32
+REDIS_URL=                         # Redis connection string
+NEXT_PUBLIC_PONDER_URL=http://localhost:42069/graphql
+```
+
+**Ponder** (`packages/ponder/.env.local`):
+
+```bash
+PONDER_RPC_URL_11155420=           # Alchemy RPC URL for Optimism Sepolia
+GITHUB_TOKEN=                      # Optional: GitHub Personal Access Token
+REDIS_URL=                         # Redis connection string (same as NextJS)
+```
+
+## Network Configuration
+
+The app is configured for Optimism Sepolia by default for local testing. To change networks, edit `packages/nextjs/scaffold.config.ts`:
+
+```typescript
+const scaffoldConfig = {
+  targetNetworks: [chains.optimismSepolia], // Change to your network
+  // ...
+};
+```
+
+Update EAS contract addresses and schema UIDs in the same file based on your target network.
 
 ## Documentation
 
-Visit our [docs](https://docs.scaffoldeth.io) to learn how to start building with Scaffold-ETH 2.
+Visit [Scaffold-ETH 2 docs](https://docs.scaffoldeth.io) to learn all the technical details and guides of Scaffold-ETH 2.
 
-To know more about its features, check out our [website](https://scaffoldeth.io).
+To know more about its features, check the [Scaffold-ETH 2 website](https://scaffoldeth.io).
 
-## Contributing to Scaffold-ETH 2
+For more information about EAS, visit the [Ethereum Attestation Service Documentation](https://docs.attest.org/).
 
-We welcome contributions to Scaffold-ETH 2!
+## Contributing
 
-Please see [CONTRIBUTING.MD](https://github.com/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) for more information and guidelines for contributing to Scaffold-ETH 2.
+We welcome contributions to Dev Creds!
+
+Please feel free to submit issues and pull requests.


### PR DESCRIPTION
Updated the generic SE-2 README with Dev Creds info, explaining what it is, how to run it, and how the attestation flow works.

Please let me know if anything feels off, missing something or if anything should be removed.