### PR TITLE
Feat/attestation UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Dev Creds Sample](https://github.com/user-attachments/assets/d9e53927-984e-4191-9c35-341884df8fb4)
 
-A decentralized developer credentials platform built with [Scaffold-ETH 2](https://github.com/scaffold-eth/scaffold-eth-2) and the [Ethereum Attestation Service (EAS)](https://attest.org/). Developers can receive and give attestations for their skills, backed by verifiable GitHub evidence, creating an on-chain reputation system for builders.
+A decentralized developer credentials platform built on Arbitrum with [Scaffold-ETH 2](https://github.com/scaffold-eth/scaffold-eth-2) and the [Ethereum Attestation Service (EAS)](https://attest.org/). Developers can receive and give attestations for their skills, backed by verifiable GitHub evidence, creating an on-chain reputation system for builders.
 
 **Key features:**
 

--- a/packages/nextjs/app/attest/page.tsx
+++ b/packages/nextjs/app/attest/page.tsx
@@ -2,7 +2,7 @@ import { Attest } from "~~/components/attestation/Attest";
 
 export default function AttestPage() {
   return (
-    <div className="min-h-[80vh] bg-base-300">
+    <div className="min-h-[80vh] bg-base-300 pb-16">
       <Attest />
     </div>
   );

--- a/packages/nextjs/app/attestations/page.tsx
+++ b/packages/nextjs/app/attestations/page.tsx
@@ -7,7 +7,7 @@ const Home: NextPage = () => {
   return (
     <>
       <div className="flex items-center flex-col grow py-10">
-        <h1 className="text-center text-4xl font-bold">Attestations</h1>
+        <h1 className="text-center text-md md:text-4xl font-bold">Attestations</h1>
         <List />
       </div>
     </>

--- a/packages/nextjs/components/SkillAutocomplete.tsx
+++ b/packages/nextjs/components/SkillAutocomplete.tsx
@@ -1,0 +1,68 @@
+import { useState } from "react";
+import { SKILLS } from "~~/utils/skills";
+
+type SkillInputProps = {
+  index: number;
+  skill: string;
+  updateSkill: (index: number, newValue: string) => void;
+};
+
+export function SkillAutocomplete({ index, skill, updateSkill }: SkillInputProps) {
+  const [open, setOpen] = useState(false);
+
+  const filtered = SKILLS.filter(s => s.toLowerCase().includes(skill.toLowerCase())).slice(0, 8);
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      if (filtered.length > 0) {
+        // take the top suggestion
+        updateSkill(index, filtered[0]);
+      } else {
+        // fallback to current input
+        updateSkill(index, skill.trim());
+      }
+      setOpen(false);
+    }
+    if (e.key === "Escape") {
+      setOpen(false);
+    }
+  };
+
+  return (
+    <div className="relative w-full">
+      <input
+        type="text"
+        value={skill}
+        onChange={e => {
+          updateSkill(index, e.target.value);
+          setOpen(true);
+        }}
+        onFocus={() => setOpen(true)}
+        onKeyDown={handleKeyDown}
+        onBlur={() => setTimeout(() => setOpen(false), 150)} // allow click
+        placeholder="Enter a skill"
+        className="input input-bordered w-full"
+      />
+
+      {open && filtered.length > 0 && (
+        <ul className="menu menu-sm dropdown-content bg-base-100 rounded-box shadow-lg absolute z-10 mt-1 w-full">
+          {filtered.map((s, i) => (
+            <li key={i}>
+              <button
+                type="button"
+                onClick={() => {
+                  updateSkill(index, s);
+                  setOpen(false);
+                }}
+                className="text-left w-full"
+              >
+                {s}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/packages/nextjs/components/SkillAutocomplete.tsx
+++ b/packages/nextjs/components/SkillAutocomplete.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import { SKILLS } from "~~/utils/skills";
 
 type SkillInputProps = {
@@ -7,57 +7,97 @@ type SkillInputProps = {
   updateSkill: (index: number, newValue: string) => void;
 };
 
+const LIMIT = { popular: 12, search: 8 };
+
 export function SkillAutocomplete({ index, skill, updateSkill }: SkillInputProps) {
-  const [open, setOpen] = useState(false);
+  const [isDropdownOpen, setDropdownOpen] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
 
-  const filtered = SKILLS.filter(s => s.toLowerCase().includes(skill.toLowerCase())).slice(0, 8);
+  const normalizedInput = skill.trim();
+  const searchTerm = normalizedInput.toLowerCase();
 
-  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+  const filteredSkills = useMemo(() => {
+    if (searchTerm === "") return SKILLS.slice(0, LIMIT.popular);
+    return SKILLS.filter(s => s.toLowerCase().includes(searchTerm)).slice(0, LIMIT.search);
+  }, [searchTerm]);
+
+  const onInputKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (!isDropdownOpen && (e.key === "ArrowDown" || e.key === "ArrowUp")) {
+      setDropdownOpen(true);
+      return;
+    }
+
     if (e.key === "Enter") {
       e.preventDefault();
-      if (filtered.length > 0) {
-        // take the top suggestion
-        updateSkill(index, filtered[0]);
-      } else {
-        // fallback to current input
-        updateSkill(index, skill.trim());
-      }
-      setOpen(false);
+
+      const chosen = filteredSkills.length > 0 ? filteredSkills[0] : searchTerm ? normalizedInput : undefined;
+
+      if (chosen) updateSkill(index, chosen);
+
+      setDropdownOpen(false);
+      inputRef.current?.blur();
+      return;
     }
+
     if (e.key === "Escape") {
-      setOpen(false);
+      setDropdownOpen(false);
+      inputRef.current?.blur();
     }
   };
+
+  const shouldRenderDropdown = isDropdownOpen && (searchTerm === "" || filteredSkills.length > 0);
 
   return (
     <div className="relative w-full">
       <input
+        ref={inputRef}
         type="text"
+        aria-haspopup="listbox"
+        autoComplete="off"
         value={skill}
         onChange={e => {
           updateSkill(index, e.target.value);
-          setOpen(true);
+          setDropdownOpen(true);
         }}
-        onFocus={() => setOpen(true)}
-        onKeyDown={handleKeyDown}
-        onBlur={() => setTimeout(() => setOpen(false), 150)}
-        placeholder="Enter a skill"
+        onFocus={() => setDropdownOpen(true)}
+        onBlur={() => setDropdownOpen(false)}
+        onKeyDown={onInputKeyDown}
+        placeholder="Type to search skills..."
         className="input input-bordered w-full"
       />
 
-      {open && filtered.length > 0 && (
-        <ul className="menu menu-sm dropdown-content bg-base-100 rounded-box shadow-lg absolute z-10 mt-1 w-full">
-          {filtered.map((skill, i) => (
+      {isDropdownOpen && searchTerm !== "" && (
+        <div className="text-xs text-base-content/70 mt-1 ml-1">
+          {filteredSkills.length === 0
+            ? `No skills found. Press Enter to use "${normalizedInput}"`
+            : `${filteredSkills.length} skill${filteredSkills.length !== 1 ? "s" : ""} found`}
+        </div>
+      )}
+
+      {shouldRenderDropdown && (
+        <ul
+          role="listbox"
+          className="menu menu-sm dropdown-content bg-base-100 rounded-box shadow-lg absolute z-10 mt-1 w-full border border-base-300"
+        >
+          {searchTerm === "" && (
+            <li className="menu-title text-xs text-base-content/60 px-3 py-2">
+              <span>Popular skills • Type to search all skills</span>
+            </li>
+          )}
+
+          {filteredSkills.map((skillOption, i) => (
             <li key={i}>
               <button
                 type="button"
-                onClick={() => {
-                  updateSkill(index, skill);
-                  setOpen(false);
+                onPointerDown={e => {
+                  e.preventDefault();
+                  updateSkill(index, skillOption);
+                  setDropdownOpen(false);
+                  inputRef.current?.blur();
                 }}
-                className="text-left w-full"
+                className="text-left w-full hover:bg-base-200"
               >
-                {skill}
+                {skillOption}
               </button>
             </li>
           ))}

--- a/packages/nextjs/components/SkillAutocomplete.tsx
+++ b/packages/nextjs/components/SkillAutocomplete.tsx
@@ -40,24 +40,24 @@ export function SkillAutocomplete({ index, skill, updateSkill }: SkillInputProps
         }}
         onFocus={() => setOpen(true)}
         onKeyDown={handleKeyDown}
-        onBlur={() => setTimeout(() => setOpen(false), 150)} // allow click
+        onBlur={() => setTimeout(() => setOpen(false), 150)}
         placeholder="Enter a skill"
         className="input input-bordered w-full"
       />
 
       {open && filtered.length > 0 && (
         <ul className="menu menu-sm dropdown-content bg-base-100 rounded-box shadow-lg absolute z-10 mt-1 w-full">
-          {filtered.map((s, i) => (
+          {filtered.map((skill, i) => (
             <li key={i}>
               <button
                 type="button"
                 onClick={() => {
-                  updateSkill(index, s);
+                  updateSkill(index, skill);
                   setOpen(false);
                 }}
                 className="text-left w-full"
               >
-                {s}
+                {skill}
               </button>
             </li>
           ))}

--- a/packages/nextjs/components/attestation/Attest.tsx
+++ b/packages/nextjs/components/attestation/Attest.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { useSearchParams } from "next/navigation";
+import { SkillAutocomplete } from "../SkillAutocomplete";
 import { EAS, SchemaEncoder } from "@ethereum-attestation-service/eas-sdk";
 import { useAccount } from "wagmi";
 import { ArrowSmallRightIcon, PlusIcon, TrashIcon } from "@heroicons/react/24/outline";
@@ -143,13 +144,7 @@ export const Attest = ({ github }: { github?: string }) => {
               <div className="space-y-2">
                 {skills.map((skill, index) => (
                   <div key={index} className="flex gap-2 items-center">
-                    <input
-                      type="text"
-                      value={skill}
-                      onChange={e => updateSkill(index, e.target.value)}
-                      placeholder="Enter a skill"
-                      className="input input-bordered flex-1"
-                    />
+                    <SkillAutocomplete index={index} skill={skill} updateSkill={updateSkill} />
                     {skills.length > 1 && (
                       <button
                         type="button"

--- a/packages/nextjs/components/attestation/Attest.tsx
+++ b/packages/nextjs/components/attestation/Attest.tsx
@@ -61,6 +61,16 @@ export const Attest = ({ github }: { github?: string }) => {
     setEvidences(updatedEvidences);
   };
 
+  const isValidUrl = (value: string) => {
+    if (!value.trim()) return true;
+    try {
+      new URL(value);
+      return true;
+    } catch {
+      return false;
+    }
+  };
+
   const signAttestation = async () => {
     if (githubUser && address && signer && eas && easConfig) {
       setIsLoading(true);
@@ -183,26 +193,32 @@ export const Attest = ({ github }: { github?: string }) => {
             <div className="flex flex-col gap-2">
               <div className="font-bold">Evidences:</div>
               <div className="space-y-2">
-                {evidences.map((evidence, index) => (
-                  <div key={index} className="flex gap-2 items-center">
-                    <input
-                      type="text"
-                      value={evidence}
-                      onChange={e => updateEvidence(index, e.target.value)}
-                      placeholder="Link to portfolio, projects, or other evidence"
-                      className="input input-bordered flex-1"
-                    />
-                    {evidences.length > 1 && (
-                      <button
-                        type="button"
-                        onClick={() => removeEvidence(index)}
-                        className="btn btn-sm btn-error btn-outline"
-                      >
-                        <TrashIcon className="w-4 h-4" />
-                      </button>
-                    )}
-                  </div>
-                ))}
+                {evidences.map((evidence, index) => {
+                  const valid = isValidUrl(evidence);
+                  return (
+                    <div key={index} className="flex flex-col gap-1">
+                      <div className="flex gap-2 items-center">
+                        <input
+                          type="text"
+                          value={evidence}
+                          onChange={e => updateEvidence(index, e.target.value)}
+                          placeholder="Link to portfolio, projects, or other evidence"
+                          className={`input input-bordered flex-1 ${!valid ? "input-error" : ""}`}
+                        />
+                        {evidences.length > 1 && (
+                          <button
+                            type="button"
+                            onClick={() => removeEvidence(index)}
+                            className="btn btn-sm btn-error btn-outline"
+                          >
+                            <TrashIcon className="w-4 h-4" />
+                          </button>
+                        )}
+                      </div>
+                      {!valid && <span className="text-error text-xs ml-1">Please enter a valid URL (https://…)</span>}
+                    </div>
+                  );
+                })}
                 <button
                   type="button"
                   onClick={addEvidence}

--- a/packages/nextjs/components/attestation/Attest.tsx
+++ b/packages/nextjs/components/attestation/Attest.tsx
@@ -233,13 +233,16 @@ export const Attest = ({ github }: { github?: string }) => {
             {/* Submit Button */}
             <div className="flex justify-center mt-8">
               <button
-                className={`btn btn-primary btn-wide rounded-full capitalize font-normal w-35 flex items-center gap-2 transition-all tracking-widest ${
-                  isLoading ? "loading" : ""
-                }`}
+                className="btn btn-primary btn-wide rounded-full capitalize font-normal w-35 flex items-center gap-2 transition-all tracking-widest"
                 disabled={isLoading || !githubUser || skills.every(skill => !skill.trim()) || !eas || !easConfig}
                 onClick={async () => await signAttestation()}
               >
-                {!isLoading && (
+                {isLoading ? (
+                  <>
+                    <span className="loading loading-spinner loading-sm"></span>
+                    Attesting...
+                  </>
+                ) : (
                   <>
                     Attest <ArrowSmallRightIcon className="w-4 h-4 mt-0.5" />
                   </>

--- a/packages/nextjs/components/attestation/Attest.tsx
+++ b/packages/nextjs/components/attestation/Attest.tsx
@@ -9,10 +9,10 @@ import scaffoldConfig from "~~/scaffold.config";
 import { notification } from "~~/utils/scaffold-eth";
 import { useSigner } from "~~/utils/useSigner";
 
-export const Attest = () => {
+export const Attest = ({ github }: { github?: string }) => {
   const searchParams = useSearchParams();
   const [isLoading, setIsLoading] = useState(false);
-  const [githubUser, setGithubUser] = useState(searchParams.get("username") || "");
+  const [githubUser, setGithubUser] = useState(searchParams.get("username") || github || "");
   const [skills, setSkills] = useState<string[]>([""]);
   const [description, setDescription] = useState("");
   const [evidences, setEvidences] = useState<string[]>([""]);
@@ -120,11 +120,10 @@ export const Attest = () => {
   };
 
   return (
-    <div className="bg-base-300 relative pb-10">
+    <div className="relative">
       <div className="w-full px-4 sm:px-6 lg:px-8">
-        <div className="mx-auto w-full max-w-2xl lg:max-w-3xl text-sm flex flex-col mt-6 px-6 sm:px-7 py-6 sm:py-8 bg-base-200/80 backdrop-blur-sm rounded-xl shadow-xl border border-base-300">
+        <div className="mx-auto w-full max-w-2xl lg:max-w-3xl text-sm flex flex-col mt-6 px-6 sm:px-7 py-6 sm:py-8 bg-base-200/80 backdrop-blur-sm rounded-xl border border-base-300">
           <span className="text-l sm:text-4xl">Attest Developer Skills</span>
-
           <div className="mt-8 space-y-6">
             {/* GitHub User */}
             <div className="flex flex-col gap-2">

--- a/packages/nextjs/components/attestation/List.tsx
+++ b/packages/nextjs/components/attestation/List.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
+import { ArrowTopRightOnSquareIcon, ChevronLeftIcon, ChevronRightIcon } from "@heroicons/react/24/outline";
 import { Address } from "~~/components/scaffold-eth";
 import scaffoldConfig from "~~/scaffold.config";
 import { fetchAttestations } from "~~/utils/graphql";
@@ -10,7 +11,7 @@ export const List = () => {
 
   const [cursor, setCursor] = useState<string | undefined>(undefined);
   const [cursors, setCursors] = useState<string[]>([]);
-  const pageSize = 20;
+  const pageSize = 15;
 
   const { data: attestationsData, isLoading } = useQuery({
     queryKey: ["attestations", cursor],
@@ -37,102 +38,136 @@ export const List = () => {
   };
 
   return (
-    <div className="list__container flex flex-col justify-center items-center py-10 px-5 sm:px-0 lg:py-auto max-w-[100vw] ">
-      <div className="flex justify-center">
-        <table className="table table-zebra w-full shadow-lg">
-          <thead>
-            <tr>
-              <th className="bg-primary text-white p-1.5 sml:p-4">UID</th>
-              <th className="bg-primary text-white p-1.5 sml:p-4">Attester</th>
-              <th className="bg-primary text-white p-1.5 sml:p-4">GitHub User</th>
-              <th className="bg-primary text-white p-1.5 sml:p-4">Skills</th>
-              <th className="bg-primary text-white p-1.5 sml:p-4">Attested at</th>
-            </tr>
-          </thead>
-          {isLoading ? (
-            <tbody>
-              {[...Array(10)].map((_, rowIndex) => (
-                <tr key={rowIndex} className="bg-base-200 hover:bg-base-300 transition-colors duration-200 h-12">
-                  {[...Array(5)].map((_, colIndex) => (
-                    <td className="w-1/4 p-1 sml:p-4" key={colIndex}>
-                      <div className="h-2 bg-gray-200 rounded-full animate-pulse"></div>
-                    </td>
-                  ))}
-                </tr>
-              ))}
-            </tbody>
-          ) : (
-            <tbody>
-              {attestationsData?.attestations.items.map(attestation => {
-                return (
-                  <tr key={attestation.id} className="hover text-sm">
-                    <td className="w-1/4 p-1 sml:p-4">
-                      <a
-                        href={`${easConfig?.scan}/attestation/view/${attestation.uid}`}
-                        title={attestation.uid}
-                        target="_blank"
-                        rel="noreferrer"
-                        className="flex"
-                      >
-                        <span className="list__container--first_row-data">{attestation.uid.slice(0, 20)}</span>...
-                      </a>
-                    </td>
-                    <td className="w-1/4 p-1 sml:p-4">
-                      <Address address={attestation.attester} size="sm" />
-                    </td>
-                    <td className="w-1/4 p-1 sml:p-4">
-                      <div className="flex flex-col gap-1">
-                        <a
-                          href={`https://github.com/${attestation.githubUser}`}
-                          target="_blank"
-                          rel="noreferrer"
-                          className="text-primary hover:underline"
-                        >
-                          @{attestation.githubUser}
-                        </a>
-                        <a
-                          href={`/attestations/${attestation.githubUser}`}
-                          className="text-xs text-secondary hover:underline"
-                        >
-                          View all attestations
-                        </a>
-                      </div>
-                    </td>
-                    <td className="w-1/4 p-1 sml:p-4">
-                      <div className="flex flex-wrap gap-1">
-                        {attestation.skills.map((skill: string, index: number) => (
-                          <span key={index} className="badge badge-primary badge-sm">
-                            {skill.trim()}
-                          </span>
-                        ))}
-                      </div>
-                    </td>
-                    <td className="text-right list__container--last_row-data p-1 sml:p-4">
-                      {new Date(attestation.timestamp * 1000).toLocaleString()}
-                    </td>
+    <div className="list__container flex flex-col justify-center items-center py-2 px-5 sm:px-0 lg:py-auto max-w-[100vw] ">
+      <div className="flex justify-center py-10 px-5 sm:px-0">
+        <div className="w-full max-w-6xl">
+          <div className="rounded-2xl shadow-xl overflow-hidden border border-base-300 bg-base-100">
+            <div className="overflow-x-auto">
+              <table className="table table-zebra w-full">
+                <thead className="bg-primary text-white">
+                  <tr>
+                    <th className="p-3 sml:p-4">Attester</th>
+                    <th className="p-3 sml:p-4">GitHub User</th>
+                    <th className="p-3 sml:p-4">Skills</th>
+                    <th className="p-3 sml:p-4">Attested at</th>
+                    <th className="p-3 pr-10 sml:p-4 text-right">Link</th>
                   </tr>
-                );
-              })}
-            </tbody>
-          )}
-        </table>
-      </div>
+                </thead>
 
-      {attestationsData && (
-        <div className="flex justify-center items-center mt-6 gap-4">
-          <button onClick={goPrevious} disabled={cursors.length === 0} className="btn btn-outline">
-            Previous
-          </button>
-          <span className="text-lg font-medium">Page {cursors.length + 1}</span>
-          <button
-            onClick={goNext}
-            disabled={!attestationsData.attestations.pageInfo.hasNextPage}
-            className="btn btn-outline"
-          >
-            Next
-          </button>
+                {isLoading ? (
+                  <tbody>
+                    {Array.from({ length: 10 }).map((_, rowIndex) => (
+                      <tr key={rowIndex} className="hover h-12">
+                        {Array.from({ length: 5 }).map((_, colIndex) => (
+                          <td key={colIndex} className="p-3 sml:p-4">
+                            <div className="h-3 rounded-full bg-base-200 animate-pulse" />
+                          </td>
+                        ))}
+                      </tr>
+                    ))}
+                  </tbody>
+                ) : (
+                  <tbody>
+                    {attestationsData?.attestations.items.map(attestation => (
+                      <tr key={attestation.id} className="hover text-sm">
+                        <td className="p-3 sml:p-4">
+                          <Address address={attestation.attester} size="sm" />
+                        </td>
+
+                        <td className="p-3 sml:p-4">
+                          <div className="flex flex-col gap-1">
+                            <a
+                              href={`https://github.com/${attestation.githubUser}`}
+                              target="_blank"
+                              rel="noreferrer"
+                              className="text-primary font-medium hover:underline"
+                            >
+                              @{attestation.githubUser}
+                            </a>
+                            <a
+                              href={`/attestations/${attestation.githubUser}`}
+                              className="text-xs text-secondary hover:underline"
+                            >
+                              View all attestations
+                            </a>
+                          </div>
+                        </td>
+
+                        <td className="p-3 sml:p-4">
+                          <div className="flex flex-wrap gap-1">
+                            {attestation.skills.map((skill: string, i: number) => (
+                              <span key={i} className="badge badge-primary badge-sm rounded-md">
+                                {skill.trim()}
+                              </span>
+                            ))}
+                          </div>
+                        </td>
+
+                        <td className="p-3 sml:p-4">
+                          <time
+                            dateTime={new Date(attestation.timestamp * 1000).toISOString()}
+                            title={new Date(attestation.timestamp * 1000).toLocaleString()}
+                            className="text-sm"
+                          >
+                            {new Date(attestation.timestamp * 1000).toLocaleDateString()}{" "}
+                            <span className="text-xs opacity-70">
+                              {new Date(attestation.timestamp * 1000).toLocaleTimeString()}
+                            </span>
+                          </time>
+                        </td>
+
+                        {/* New Link column with verify arrow */}
+                        <td className="p-3 sml:p-4 text-right">
+                          <a
+                            href={`${easConfig?.scan}/attestation/view/${attestation.uid}`}
+                            target="_blank"
+                            rel="noreferrer"
+                            className="btn btn-sm btn-ghost gap-1 rounded-full"
+                            aria-label="Verify on explorer"
+                            title={attestation.uid}
+                          >
+                            <span className="hidden sm:inline">Verify</span>
+                            <ArrowTopRightOnSquareIcon className="h-4 w-4" />
+                          </a>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                )}
+              </table>
+            </div>
+
+            {attestationsData && (
+              <div className="flex justify-between items-center px-4 py-3 bg-base-100 border-t border-base-300">
+                <span className="text-sm opacity-80">Page {cursors.length + 1}</span>
+                <div className="flex items-center gap-2">
+                  <button
+                    onClick={goPrevious}
+                    disabled={cursors.length === 0}
+                    className="btn btn-outline btn-sm rounded-full"
+                  >
+                    <ChevronLeftIcon className="h-4 w-4" />
+                  </button>
+                  <button
+                    onClick={goNext}
+                    disabled={!attestationsData.attestations.pageInfo.hasNextPage}
+                    className="btn btn-outline btn-sm rounded-full"
+                  >
+                    <ChevronRightIcon className="h-4 w-4" />
+                  </button>
+                </div>
+              </div>
+            )}
+          </div>
+          {/* Empty state */}
+          {!isLoading && !attestationsData?.attestations.items?.length && (
+            <div className="mt-6 flex flex-col items-center gap-2 text-center">
+              <div className="text-lg font-medium">No attestations yet</div>
+              <div className="text-sm opacity-70">They’ll show up here as soon as you have some.</div>
+            </div>
+          )}
         </div>
-      )}
+      </div>
     </div>
   );
 };

--- a/packages/nextjs/components/builder/Attestations.tsx
+++ b/packages/nextjs/components/builder/Attestations.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { Address } from "../scaffold-eth";
 import { CheckCircleIcon } from "@heroicons/react/24/outline";
 import { Attestation, Developer } from "~~/types";
 
@@ -7,21 +8,15 @@ function AttestationCard({ attestation }: { attestation: Attestation }) {
     <div className="relative border-l-2 border-primary/20 pl-4 space-y-3">
       <div className="flex items-start justify-between">
         <div className="flex items-center gap-3">
-          <div className="avatar">
-            <div className="mask mask-squircle h-10 w-10 bg-base-200"></div>
-          </div>
           <div>
             <div className="flex flex-col sm:flex-row sm:items-center gap-1 sm:gap-2">
-              <span className="font-medium text-base-content">(placeholderforcompute)</span>
+              <Address address={attestation.attester} size="base" onlyEnsOrAddress />
               {attestation.verified && (
                 <div className="badge badge-outline badge-success badge-sm">
                   <CheckCircleIcon className="mr-1 h-3 w-3" />
                   Verified
                 </div>
               )}
-            </div>
-            <div className="flex items-center gap-2 text-xs sm:text-sm text-base-content/70">
-              <span>@{attestation.attester}</span>
             </div>
           </div>
         </div>

--- a/packages/nextjs/components/builder/ProfileHeader.tsx
+++ b/packages/nextjs/components/builder/ProfileHeader.tsx
@@ -1,10 +1,13 @@
+import { useState } from "react";
 import Link from "next/link";
 import { ReusuableStats } from "../DisplayStats";
 import { GithubSVG } from "../assets/GithubSVG";
+import { Attest } from "../attestation/Attest";
 import { ChatBubbleLeftRightIcon } from "@heroicons/react/24/outline";
 import { Developer } from "~~/types";
 
 export function ProfileHeader({ developer }: { developer: Developer }) {
+  const [open, setOpen] = useState(false);
   const avatarUrl = `https://github.com/${developer.githubUser}.png`;
   const githubUrl = `https://github.com/${developer.githubUser}`;
   const stats = [
@@ -33,15 +36,14 @@ export function ProfileHeader({ developer }: { developer: Developer }) {
                 <GithubSVG />
                 GitHub
               </Link>
-              <Link
-                href={{ pathname: "/attest", query: { username: developer.githubUser } }}
+              <button
                 className="btn btn-primary btn-sm flex items-center gap-2"
-                prefetch={false}
+                onClick={() => setOpen(true)}
                 aria-label={`Attest for ${developer.githubUser}`}
               >
                 <ChatBubbleLeftRightIcon className="h-4 w-4" />
                 <span>Attest</span>
-              </Link>
+              </button>
             </div>
           </div>
 
@@ -54,6 +56,19 @@ export function ProfileHeader({ developer }: { developer: Developer }) {
             <ReusuableStats stats={stats} />
           </div>
         </div>
+        <dialog id="attest-modal" className={`modal ${open ? "modal-open" : ""}`}>
+          <div className="modal-box w-11/12 max-w-2xl rounded-xl">
+            <Attest github={developer.githubUser} />
+            <div className="modal-action">
+              <button onClick={() => setOpen(false)} className="btn btn-primary btn-sm">
+                Close
+              </button>
+            </div>
+          </div>
+          <form method="dialog" className="modal-backdrop">
+            <button onClick={() => setOpen(false)}>close</button>
+          </form>
+        </dialog>
       </div>
     </div>
   );

--- a/packages/nextjs/utils/skills.ts
+++ b/packages/nextjs/utils/skills.ts
@@ -34,6 +34,21 @@ export const SKILLS = [
   "Graph Protocol",
   "Subgraph",
   "Ponder",
+  "IPFS",
+  "Ethers.js",
+  "Tenderly",
+  "WalletConnect",
+
+  // Web3 Concepts
+  "Tokenomics Design",
+  "Layer 2 - Scaling",
+  "Account Abstraction",
+  "Oracles",
+  "MEV",
+  "Smart Contract Security",
+  "Gas Optimization",
+  "Upgradeable Contracts",
+  "Flashloans",
 
   // DevOps & Infra
   "Docker",
@@ -56,6 +71,9 @@ export const SKILLS = [
   "Mocha",
   "Chai",
   "Vitest",
+  "Cypress",
+  "Playwright",
+  "Synpress",
 
   // Misc
   "Git",

--- a/packages/nextjs/utils/skills.ts
+++ b/packages/nextjs/utils/skills.ts
@@ -1,0 +1,66 @@
+export const SKILLS = [
+  // Languages
+  "Solidity",
+  "Rust",
+  "JavaScript",
+  "TypeScript",
+  "Python",
+  "Go",
+  "Java",
+  "C++",
+  "C#",
+  "SQL",
+  "HTML",
+  "CSS",
+
+  // Frameworks & Libraries
+  "React",
+  "Next.js",
+  "Vue.js",
+  "Angular",
+  "Node.js",
+  "Express",
+  "TailwindCSS",
+  "Styled Components",
+
+  // Web3 / Blockchain
+  "Hardhat",
+  "Foundry",
+  "Truffle",
+  "Viem",
+  "Wagmi",
+  "RainbowKit",
+  "Scaffold-ETH",
+  "Graph Protocol",
+  "Subgraph",
+  "Ponder",
+
+  // DevOps & Infra
+  "Docker",
+  "Kubernetes",
+  "AWS",
+  "GCP",
+  "Azure",
+  "CI/CD",
+  "Linux",
+
+  // Data
+  "PostgreSQL",
+  "MongoDB",
+  "Redis",
+  "GraphQL",
+  "REST APIs",
+
+  // Testing
+  "Jest",
+  "Mocha",
+  "Chai",
+  "Vitest",
+
+  // Misc
+  "Git",
+  "GitHub Actions",
+  "Figma",
+  "Agile",
+  "Scrum",
+];


### PR DESCRIPTION
This PR covers - 
#4 - improved form to open as modal for builder page + added validations for evidences to be valid urls
#5  - improved attestations list table 
#44 - hardcoded list of skills with Autocomplete
Also covers replacing placeholder for compute on builder page to show Address component

Working - 

https://github.com/user-attachments/assets/dbf0df95-b78b-46c7-89c0-30a76f5a39f1


<img width="1509" height="565" alt="Screenshot 2025-10-01 at 7 41 53 PM" src="https://github.com/user-attachments/assets/8d7f9e48-710a-4241-80f9-334df40eca44" />
