### PR TITLE
Collaborator and verified badges

### DIFF
--- a/packages/nextjs/components/attestation/UserAttestations.tsx
+++ b/packages/nextjs/components/attestation/UserAttestations.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
+import { UsersIcon } from "@heroicons/react/24/outline";
 import { Address } from "~~/components/scaffold-eth";
 import scaffoldConfig from "~~/scaffold.config";
 import { fetchUserAttestations } from "~~/utils/graphql";
@@ -115,7 +116,17 @@ export const UserAttestations = ({ githubUser }: Props) => {
                 <div className="flex justify-between items-start mb-4">
                   <div>
                     <h3 className="font-semibold text-lg mb-1">
-                      Attestation by <Address address={attestation.attester} size="sm" />
+                      Attestation by
+                      <div className="flex items-center gap-2">
+                        <Address address={attestation.attester} size="sm" />
+                        {attestation.evidencesCollaborator.some(collaborator => collaborator === true) && (
+                          <div className="tooltip" data-tip="Collaborator">
+                            <div className="badge badge-outline badge-primary badge-sm">
+                              <UsersIcon className="mr-1 h-4 w-4" />
+                            </div>
+                          </div>
+                        )}
+                      </div>
                     </h3>
                     <p className="text-sm text-base-content/70">
                       {new Date(attestation.timestamp * 1000).toLocaleDateString()}

--- a/packages/nextjs/components/builder/Attestations.tsx
+++ b/packages/nextjs/components/builder/Attestations.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 import { Address } from "../scaffold-eth";
-import { CheckCircleIcon } from "@heroicons/react/24/outline";
+import { CheckCircleIcon, UsersIcon } from "@heroicons/react/24/outline";
 import { Attestation, Developer } from "~~/types";
 
 function AttestationCard({ attestation }: { attestation: Attestation }) {
@@ -11,10 +11,11 @@ function AttestationCard({ attestation }: { attestation: Attestation }) {
           <div>
             <div className="flex flex-col sm:flex-row sm:items-center gap-1 sm:gap-2">
               <Address address={attestation.attester} size="base" onlyEnsOrAddress />
-              {attestation.verified && (
-                <div className="badge badge-outline badge-success badge-sm">
-                  <CheckCircleIcon className="mr-1 h-3 w-3" />
-                  Verified
+              {attestation.evidencesCollaborator.some(collaborator => collaborator === true) && (
+                <div className="tooltip" data-tip="Collaborator">
+                  <div className="badge badge-outline badge-primary badge-sm">
+                    <UsersIcon className="mr-1 h-4 w-4" />
+                  </div>
                 </div>
               )}
             </div>
@@ -35,15 +36,21 @@ function AttestationCard({ attestation }: { attestation: Attestation }) {
         </div>
         <p className="text-base-content text-sm sm:text-base">{attestation.description}</p>
         {attestation?.evidences?.map((url, i) => (
-          <Link
-            key={i}
-            target="_blank"
-            href={url}
-            rel="noopener noreferrer"
-            className="block text-xs sm:text-sm text-base-content/70 underline hover:text-primary"
-          >
-            {url}
-          </Link>
+          <div key={i} className="flex items-center gap-2">
+            <Link
+              target="_blank"
+              href={url}
+              rel="noopener noreferrer"
+              className="block text-xs sm:text-sm text-base-content/70 underline hover:text-primary"
+            >
+              {url}
+            </Link>
+            {attestation.evidencesVerified[i] && (
+              <div className="tooltip" data-tip="Verified">
+                <CheckCircleIcon className="mr-1 h-4 w-4 text-success" />
+              </div>
+            )}
+          </div>
         ))}
       </div>
     </div>

--- a/packages/nextjs/utils/graphql.ts
+++ b/packages/nextjs/utils/graphql.ts
@@ -59,6 +59,8 @@ export const fetchUserAttestations = async (
           skills
           description
           evidences
+          evidencesVerified
+          evidencesCollaborator
           timestamp
         }
         pageInfo {
@@ -137,6 +139,8 @@ export const fetchDeveloper = async (githubUser: string): Promise<Developer> => 
             skills
             description
             evidences
+            evidencesVerified
+            evidencesCollaborator
             timestamp
           }
         }


### PR DESCRIPTION
Add collaborator badge to builder attestations (builder page and builder attestations page) and attestation verified check on the builder page.

Builder page:

<img width="778" height="263" alt="Screenshot from 2025-10-03 13-59-28" src="https://github.com/user-attachments/assets/15acf505-ad7f-440c-b667-4972f1121e99" />

Builder attestation page:

<img width="300" height="155" alt="Screenshot from 2025-10-03 13-58-36" src="https://github.com/user-attachments/assets/b9535e78-70c8-49dd-ade2-aec5871edc2b" />

Tooltips are shown by hovering over the icons.

The verification links are shown in a different way on the builder page and builder attestation page: as normal link text on the builder page (see first screenshot up) and as a badge on the builder attestation page.

<img width="778" height="149" alt="Screenshot from 2025-10-03 14-15-41" src="https://github.com/user-attachments/assets/e6952c52-ff71-4d2d-b881-79a4ed66664e" />

We should select which way is better and use the same format in all places.

relates #36 