### PR TITLE
Improve developers search

### DIFF
--- a/packages/nextjs/components/BuildersFilter.tsx
+++ b/packages/nextjs/components/BuildersFilter.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect, useMemo, useRef, useState } from "react";
-import { DeveloperForTable } from "./BuildersTable";
 import { MagnifyingGlassIcon } from "@heroicons/react/20/solid";
 import { ChevronDownIcon, XMarkIcon } from "@heroicons/react/24/outline";
 
@@ -33,27 +32,6 @@ function normalizeSkills(skills: string[]) {
   return Array.from(normalizedMap.entries())
     .sort((left, right) => left[1].localeCompare(right[1]))
     .map(([key, label]) => ({ key, label }));
-}
-
-export function filterDevelopers(
-  developers: DeveloperForTable[],
-  selectedSkillKeys: string[],
-  usernameSubstring: string,
-) {
-  const hasSkillFilter = selectedSkillKeys.length > 0;
-  const normalizedSelected = new Set(selectedSkillKeys.map(normalizeSkill));
-  const normalizedUsernameSubstring = usernameSubstring.trim().toLowerCase();
-
-  return developers.filter(developer => {
-    const usernameMatches =
-      normalizedUsernameSubstring.length === 0 ||
-      developer.username.toLowerCase().includes(normalizedUsernameSubstring);
-
-    const skillsMatch =
-      !hasSkillFilter || developer.skills.some(skill => normalizedSelected.has(normalizeSkill(skill)));
-
-    return usernameMatches && skillsMatch;
-  });
 }
 
 export function BuildersFilter({

--- a/packages/nextjs/types/index.ts
+++ b/packages/nextjs/types/index.ts
@@ -75,10 +75,54 @@ type Developer = {
   };
 };
 
+type DeveloperResult = {
+  githubUser: string;
+  name: string;
+  bio: string;
+  location: string;
+  website: string;
+  twitter: string;
+  attestationsCount: number;
+  verifiedAttestationsCount: number;
+  colaboratorAttestationsCount: number;
+  score: number;
+  updatedAt: number;
+  matchedSkillsScore: number;
+  skills: {
+    skill: string;
+    count: number;
+    verifiedCount: number;
+    collaboratorCount: number;
+    score: number;
+  }[];
+};
+
+type DeveloperResultPage = {
+  data: DeveloperResult[];
+  pagination: {
+    totalCount: number;
+    totalPages: number;
+    currentPage: number;
+    limit: number;
+    offset: number;
+    hasNextPage: boolean;
+    hasPreviousPage: boolean;
+  };
+};
+
 type SearchData = {
   developers: {
     items: Developer[];
   };
 };
 
-export type { Attestation, Skill, AttestationsData, SkillsData, Developer, SearchData };
+export type {
+  Attestation,
+  Skill,
+  AttestationsData,
+  SkillsData,
+  Developer,
+  SearchData,
+  DeveloperResult,
+  DeveloperResultPage,
+};

--- a/packages/nextjs/utils/graphql.ts
+++ b/packages/nextjs/utils/graphql.ts
@@ -1,7 +1,6 @@
 import { gql, request } from "graphql-request";
-import { DeveloperForTable } from "~~/components/BuildersTable";
 import { PONDER_GRAPHQL_URL } from "~~/scaffold.config";
-import { AttestationsData, Developer, SearchData, SkillsData } from "~~/types";
+import { AttestationsData, Developer, DeveloperResultPage, SearchData, SkillsData } from "~~/types";
 
 type DeveloperResponse = {
   developer: Developer;
@@ -185,79 +184,26 @@ export const searchDevelopers = async (githubUsername: string): Promise<SearchDa
   return data;
 };
 
-type DevPage = {
-  developers: DeveloperForTable[];
-  pageInfo: { hasNextPage: boolean; endCursor?: string | null };
+export const fetchDevelopersForTable = async ({
+  pageSize,
+  offset,
+  skills,
+  search,
+}: {
+  pageSize: number;
+  offset?: number;
+  skills?: string[];
+  search?: string;
+}): Promise<DeveloperResultPage> => {
+  const response = await fetch(
+    `${PONDER_GRAPHQL_URL}/builders?limit=${pageSize}&offset=${offset}${skills !== undefined && skills.length > 0 ? `&skills=${skills?.join("&skills=")}` : ""}${search !== undefined && search.length > 0 ? `&search=${search}` : ""}`,
+  );
+  const data = await response.json();
+  return data;
 };
 
-export const fetchDevelopersForTable = async (pageSize: number = 20, cursor?: string): Promise<DevPage> => {
-  const DevelopersForTable = gql`
-    query DevelopersForTable($limit: Int!, $after: String, $since: Int!) {
-      developers(limit: $limit, after: $after, orderBy: "githubUser", orderDirection: "asc") {
-        items {
-          githubUser
-          skills {
-            items {
-              skill
-            }
-          }
-          attestations(where: { timestamp_gte: $since }) {
-            totalCount
-            items {
-              attester
-            }
-          }
-        }
-        pageInfo {
-          hasNextPage
-          endCursor
-        }
-      }
-    }
-  `;
-
-  const THIRTY_DAYS = Math.floor(Date.now() / 1000) - 30 * 24 * 60 * 60;
-  const variables: { limit: number; since: number; after?: string } = { limit: pageSize, since: THIRTY_DAYS };
-  if (cursor) variables.after = cursor;
-
-  const data = await request<any>(PONDER_GRAPHQL_URL, DevelopersForTable, variables);
-
-  const items = data?.developers?.items ?? [];
-
-  const developers: DeveloperForTable[] = items.map((d: any) => {
-    const username = (d.githubUser ?? "").trim();
-
-    const skills: string[] = Array.from(new Set((d.skills?.items ?? []).map((s: any) => s?.skill).filter(Boolean)));
-
-    const attesters: string[] = Array.from(
-      new Set((d.attestations?.items ?? []).map((a: any) => a?.attester).filter(Boolean)),
-    );
-
-    const monthlyTotal = d?.attestations?.totalCount ?? 0;
-
-    return {
-      name: username,
-      username,
-      avatar: `https://github.com/${username}.png`,
-      githubUrl: `https://github.com/${username}`,
-      monthlyAttestations: monthlyTotal,
-      skills,
-      attestations: {
-        total: monthlyTotal,
-        verified: 0,
-      },
-      topCollaborators: attesters,
-    };
-  });
-
-  developers.sort((a, b) =>
-    b.attestations.total !== a.attestations.total
-      ? b.attestations.total - a.attestations.total
-      : a.username.localeCompare(b.username),
-  );
-
-  return {
-    developers,
-    pageInfo: data?.developers?.pageInfo ?? { hasNextPage: false, endCursor: null },
-  };
+export const fetchSkills = async (): Promise<string[]> => {
+  const response = await fetch(`${PONDER_GRAPHQL_URL}/skills`);
+  const data = await response.json();
+  return data.data;
 };

--- a/packages/ponder/src/Attestations.ts
+++ b/packages/ponder/src/Attestations.ts
@@ -196,7 +196,7 @@ ponder.on("EAS:Attested", async ({ event, context }) => {
                 }
                 await context.db.insert(developerSkill).values({
                     githubUser: githubUser,
-                    skill: skill,
+                    skill: skill.toLowerCase(),
                     count: 1,
                     verifiedCount: verifiedCount,
                     collaboratorCount: collaboratorCount,

--- a/packages/ponder/src/api/index.ts
+++ b/packages/ponder/src/api/index.ts
@@ -1,0 +1,205 @@
+import { ponder } from "ponder:registry";
+import { graphql, count, sql, gte, eq, and, like } from "ponder";
+import { developer, developerSkill } from "ponder:schema";
+
+ponder.use("/", graphql());
+ponder.use("/graphql", graphql());
+
+ponder.get("/skills", async (c) => {
+  const skills = await c.db
+    .selectDistinct({
+      skill: developerSkill.skill,
+    })
+    .from(developerSkill)
+    .orderBy(developerSkill.skill);
+
+  return c.json({
+    data: skills.map((s) => s.skill),
+  });
+});
+
+ponder.get("/builders", async (c) => {
+  const skills = c.req.queries("skills");
+  const limitParam = c.req.query("limit");
+  const offsetParam = c.req.query("offset");
+  const searchParam = c.req.query("search");
+
+  const normalizedSkills =
+    skills !== undefined && skills.length > 0
+      ? skills.map((skill: string) => skill.toLowerCase())
+      : [];
+  const limit = limitParam ? parseInt(limitParam, 10) : 20; // Default to 20 items per page
+  const offset = offsetParam ? parseInt(offsetParam, 10) : 0; // Default to first page
+  const search = searchParam ? searchParam.toLowerCase() : "";
+
+  let builders;
+
+  let totalCount = 0;
+
+  if (normalizedSkills.length > 0) {
+    // Build WHERE conditions
+    const skillsCondition = sql`${developer.githubUser} IN (
+            SELECT ${developerSkill.githubUser}
+            FROM ${developerSkill}
+            WHERE ${developerSkill.skill} IN (${sql.join(
+      normalizedSkills.map((skill) => sql`${skill}`),
+      sql`, `
+    )})
+            GROUP BY ${developerSkill.githubUser}
+            HAVING COUNT(DISTINCT ${developerSkill.skill}) = ${
+      normalizedSkills.length
+    }
+        )`;
+
+    const whereConditions = search
+      ? and(skillsCondition, like(developer.githubUser, `%${search}%`))
+      : skillsCondition;
+
+    // Get total count for pagination metadata
+    const countResult = await c.db
+      .select({ count: count() })
+      .from(developer)
+      .where(whereConditions);
+    totalCount = countResult[0]?.count || 0;
+
+    // Find developers who have ALL the specified skills with pagination, ordered by matched skills score
+    const developersWithScore = await c.db
+      .select({
+        githubUser: developer.githubUser,
+        name: developer.name,
+        bio: developer.bio,
+        location: developer.location,
+        website: developer.website,
+        twitter: developer.twitter,
+        attestationsCount: developer.attestationsCount,
+        verifiedAttestationsCount: developer.verifiedAttestationsCount,
+        colaboratorAttestationsCount: developer.colaboratorAttestationsCount,
+        score: developer.score,
+        updatedAt: developer.updatedAt,
+        matchedSkillsScore:
+          sql<number>`COALESCE(SUM(${developerSkill.score}), 0)`.as(
+            "matchedSkillsScore"
+          ),
+      })
+      .from(developer)
+      .leftJoin(
+        developerSkill,
+        and(
+          eq(developerSkill.githubUser, developer.githubUser),
+          sql`${developerSkill.skill} IN (${sql.join(
+            normalizedSkills.map((skill) => sql`${skill}`),
+            sql`, `
+          )})`
+        )
+      )
+      .where(whereConditions)
+      .groupBy(developer.githubUser)
+      .orderBy(sql`COALESCE(SUM(${developerSkill.score}), 0) DESC`)
+      .limit(limit)
+      .offset(offset);
+
+    // Fetch all skills for each developer
+    const githubUsers = developersWithScore.map((d) => d.githubUser);
+    const allSkills =
+      githubUsers.length > 0
+        ? await c.db
+            .select()
+            .from(developerSkill)
+            .where(
+              sql`${developerSkill.githubUser} IN (${sql.join(
+                githubUsers.map((user) => sql`${user}`),
+                sql`, `
+              )})`
+            )
+            .orderBy(developerSkill.score)
+        : [];
+
+    // Group skills by developer
+    const skillsByDeveloper: Record<string, typeof allSkills> = {};
+    allSkills.forEach((skill) => {
+      if (!skillsByDeveloper[skill.githubUser]) {
+        skillsByDeveloper[skill.githubUser] = [];
+      }
+      skillsByDeveloper[skill.githubUser]?.push(skill);
+    });
+
+    // Add skills to each developer
+    builders = developersWithScore.map((dev) => ({
+      ...dev,
+      skills: skillsByDeveloper[dev.githubUser] || [],
+    }));
+  } else {
+    // Get total count for all developers
+    const countResult = search
+      ? await c.db
+          .select({ count: count() })
+          .from(developer)
+          .where(like(developer.githubUser, `%${search}%`))
+      : await c.db.select({ count: count() }).from(developer);
+    totalCount = countResult[0]?.count || 0;
+
+    // If no skills specified, return all developers with pagination, ordered by total score
+    const developersData = search
+      ? await c.db
+          .select()
+          .from(developer)
+          .where(like(developer.githubUser, `%${search}%`))
+          .orderBy(sql`${developer.score} DESC`)
+          .limit(limit)
+          .offset(offset)
+      : await c.db.query.developer.findMany({
+          limit: limit,
+          offset: offset,
+          orderBy: (developer, { desc }) => [desc(developer.score)],
+        });
+
+    // Fetch all skills for each developer
+    const githubUsers = developersData.map((d) => d.githubUser);
+    const allSkills =
+      githubUsers.length > 0
+        ? await c.db
+            .select()
+            .from(developerSkill)
+            .where(
+              sql`${developerSkill.githubUser} IN (${sql.join(
+                githubUsers.map((user) => sql`${user}`),
+                sql`, `
+              )})`
+            )
+            .orderBy(developerSkill.score)
+        : [];
+
+    // Group skills by developer
+    const skillsByDeveloper: Record<string, typeof allSkills> = {};
+    allSkills.forEach((skill) => {
+      if (!skillsByDeveloper[skill.githubUser]) {
+        skillsByDeveloper[skill.githubUser] = [];
+      }
+      skillsByDeveloper[skill.githubUser]?.push(skill);
+    });
+
+    // Add skills to each developer
+    builders = developersData.map((dev) => ({
+      ...dev,
+      skills: skillsByDeveloper[dev.githubUser] || [],
+    }));
+  }
+
+  const totalPages = Math.ceil(totalCount / limit);
+  const currentPage = Math.floor(offset / limit) + 1;
+  const hasNextPage = offset + limit < totalCount;
+  const hasPreviousPage = offset > 0;
+
+  return c.json({
+    data: builders,
+    pagination: {
+      totalCount,
+      totalPages,
+      currentPage,
+      limit,
+      offset,
+      hasNextPage,
+      hasPreviousPage,
+    },
+  });
+});


### PR DESCRIPTION
- Added a Ponder API endpoint to search for developers.
- Added another Ponder API endpoint to get all the attested skills.
- Use these endpoints in the builders page, moving the skills filtering from the frontend to the API endpoint.
- Save developer skills to lowercase.
- The builder's query is complex, but it only takes 2 queries to get the builders and the skills. We need to check if we need to add some indexes to the tables, or maybe we can denormalize some developer skills data (skill and score) and save this information as an array at the developer table.

closes #38 