### PR TITLE
Add Arbitrum schema

### DIFF
--- a/packages/nextjs/contracts/externalContracts.ts
+++ b/packages/nextjs/contracts/externalContracts.ts
@@ -1060,6 +1060,7 @@ const externalContracts = {
     EAS: {
       address: "0xbD75f629A22Dc1ceD33dDA0b68c546A1c035c458",
       abi: EAS_ABI,
+      deployedOnBlock: 390564122,
     },
   },
 } as const;

--- a/packages/nextjs/scaffold.config.ts
+++ b/packages/nextjs/scaffold.config.ts
@@ -25,7 +25,7 @@ export const PONDER_GRAPHQL_URL = process.env.NEXT_PUBLIC_PONDER_URL || "http://
 
 const scaffoldConfig = {
   // The networks on which your DApp is live
-  targetNetworks: [chains.optimismSepolia],
+  targetNetworks: [chains.arbitrum],
   // The interval at which your front-end polls the RPC servers for new data (it has no effect if you only target the local network (default is 4000))
   pollingInterval: 30000,
   // This is ours Alchemy's default API key.
@@ -61,7 +61,7 @@ const scaffoldConfig = {
     },
     [chains.arbitrum.id]: {
       contractAddress: "0xbD75f629A22Dc1ceD33dDA0b68c546A1c035c458",
-      schemaUID: "",
+      schemaUID: "0xed8c209ab79c5b66eba9a2a9806320b30513bd186712d790fd5cb7fc24eb3416",
       scan: "https://arbitrum.easscan.org",
       graphUri: "https://arbitrum.easscan.org/graphql",
     },


### PR DESCRIPTION
- Arbitrum schema created: https://arbitrum.easscan.org/schema/view/0xed8c209ab79c5b66eba9a2a9806320b30513bd186712d790fd5cb7fc24eb3416
- Set Arbitrum as the default target network.
- Add deployedOnBlock for the Arbitrum EAS contract.

closes #10 