### PR TITLE
Fix for miniapp meta tag generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,6 @@ Dev Creds works as a Farcaster MiniApp. Here's what you need to configure:
 **NextJS** (`packages/nextjs/.env.local`):
 
 ```bash
-NEXT_PUBLIC_URL=https://your.live.url
 NEXT_PUBLIC_APP_AUTOADD=false # Change to true if you want your MiniApp to prompt user to add it to favorites on open
 ```
 

--- a/packages/nextjs/.env.example
+++ b/packages/nextjs/.env.example
@@ -17,7 +17,5 @@ NEXTAUTH_SECRET=
 REDIS_URL=
 NEXT_PUBLIC_PONDER_URL=http://localhost:42069/graphql
 
-NEXT_PUBLIC_URL=https://dev-creds.vercel.app
-
 NEXT_PUBLIC_APP_AUTOADD=false
 

--- a/packages/nextjs/app/builder/[username]/page.tsx
+++ b/packages/nextjs/app/builder/[username]/page.tsx
@@ -9,7 +9,7 @@ export async function generateMetadata({ params }: { params: Promise<{ username:
     title: `${username} Developer Attested Skills`,
     description: `View ${username}'s verified developer reputation, skills, and attestations on DevCreds.`,
     imageRelativePath: `/builder/${username}/og.png`,
-    url: process.env.NEXT_PUBLIC_URL + `/builder/${username}`,
+    url: `/builder/${username}`,
   });
 }
 

--- a/packages/nextjs/scaffold.config.ts
+++ b/packages/nextjs/scaffold.config.ts
@@ -24,6 +24,10 @@ export const DEFAULT_ALCHEMY_API_KEY = "oKxs-03sij-U_N0iOlrSsZFr29-IqbuF";
 
 export const PONDER_GRAPHQL_URL = process.env.NEXT_PUBLIC_PONDER_URL || "http://localhost:42069";
 
+const baseUrl = process.env.VERCEL_PROJECT_PRODUCTION_URL
+  ? `https://${process.env.VERCEL_PROJECT_PRODUCTION_URL}`
+  : `http://localhost:${process.env.PORT || 3000}`;
+
 const scaffoldConfig = {
   // The networks on which your DApp is live
   targetNetworks: [chains.arbitrum],
@@ -72,11 +76,11 @@ const scaffoldConfig = {
     subtitle: "Developer Reputation On-Chain", // Max length: 30 characters
     description:
       "DevCreds is a verifiable developer skill ledger on Arbitrum. Get peer attestations, showcase your expertise, and build trust in the Web3 ecosystem.",
-    icon: process.env.NEXT_PUBLIC_URL + "/favicon.png",
-    image: process.env.NEXT_PUBLIC_URL + "/thumbnail.jpg",
-    splashImage: process.env.NEXT_PUBLIC_URL + "/favicon.png",
+    icon: baseUrl + "/favicon.png",
+    image: baseUrl + "/thumbnail.jpg",
+    splashImage: baseUrl + "/favicon.png",
     splashBackgroundColor: "#1E293B",
-    appImage: process.env.NEXT_PUBLIC_URL + "/thumbnail.jpg",
+    appImage: baseUrl + "/thumbnail.jpg",
   },
 } as const satisfies ScaffoldConfig;
 

--- a/packages/nextjs/utils/scaffold-eth/getMetadata.ts
+++ b/packages/nextjs/utils/scaffold-eth/getMetadata.ts
@@ -1,7 +1,9 @@
 import type { Metadata } from "next";
 import scaffoldConfig from "~~/scaffold.config";
 
-const baseUrl = process.env.NEXT_PUBLIC_URL ?? `http://localhost:${process.env.PORT || 3000}`;
+const baseUrl = process.env.VERCEL_PROJECT_PRODUCTION_URL
+  ? `https://${process.env.VERCEL_PROJECT_PRODUCTION_URL}`
+  : `http://localhost:${process.env.PORT || 3000}`;
 const titleTemplate = "%s | DevCreds";
 
 export const getMetadata = ({
@@ -16,7 +18,7 @@ export const getMetadata = ({
   url?: string;
 }): Metadata => {
   const imageUrl = `${baseUrl}${imageRelativePath}`;
-  const effectiveUrl = url || baseUrl;
+  const effectiveUrl = url ? `${baseUrl}${url}` : baseUrl;
   const miniAppContent = JSON.stringify({
     version: "1",
     imageUrl: imageUrl,


### PR DESCRIPTION
Removed NEXT_PUBLIC_URL and use VERCEL_PROJECT_PRODUCTION_URL for meta tag url generation.